### PR TITLE
对 2.0.2-pre 版本的小修小改

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ node_modules/
 
 *.code-workspace
 .vscode/
+
+
+assets/themes/liora

--- a/assets/styles/index.css
+++ b/assets/styles/index.css
@@ -44,7 +44,7 @@ body {
 .page-head {
     display: flex;
     justify-content: center;
-    align-items: center;
+    /* align-items: center; */ /* [^1] 开这玩意儿实现打字标题居中会导致页面跳动，我也不知道这是为甚么 TAT */
     width: 100%;
     height: 320px;
     background-color: #49b1f5;
@@ -56,7 +56,7 @@ body {
 
 .page-head > .title,
 .page-head > .typed-cursor {
-    margin-top: 32px;
+    margin-top: 160px; /* [^1] 所以此处使用上边距实现居中，反正能跑就行（ */
     font-size: 32px;
     font-weight: bold;
     color: #ffffff;
@@ -206,7 +206,8 @@ body {
     }
 }
 
-.primary-container > .left-area > .cards > .card-item > .content > .settings-item > .themes > .theme-item, .primary-container > .left-area > .cards > .card-item > .content > .settings-item > .themes > .theme-item * {
+.primary-container > .left-area > .cards > .card-item > .content > .settings-item > .themes > .theme-item,
+.primary-container > .left-area > .cards > .card-item > .content > .settings-item > .themes > .theme-item * {
     cursor: url(https://cdn.jsdelivr.net/gh/honjun/cdn@1.6/img/cursor/ayuda.cur), pointer;
 }
 

--- a/config.json
+++ b/config.json
@@ -2,6 +2,7 @@
     "title": "成成0v0 の 个人网站",
     "theme": {
         "theme": "defdark",
+        "displayName": "Default",
         "colors": {
             "autoSwitch": {
                 "displayName": "Auto",

--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
                         <span class="title"><i class="fa-solid fa-sliders"></i>浏览设置</span>
                         <div class="content">
                             <div class="settings-item theme-settings">
-                                <span class="title"><i class="fa-solid fa-shirt"></i>配色方案</span>
+                                <span class="title"><i class="fa-solid fa-shirt"></i>配色方案 · <span x-text="config.content.theme.displayName"></span></span>
                                 <div class="themes"></div>
                             </div>
                         </div>


### PR DESCRIPTION
## 新功能/改动
- 在配色方案设置区域的标题右侧显示主题名称

## 修复
- 修复了页首打字标题导致页面跳动的问题